### PR TITLE
Fix assertion of pop() result in test_issue_4920

### DIFF
--- a/Lib/test/test_collections.py
+++ b/Lib/test/test_collections.py
@@ -1512,8 +1512,12 @@ class TestCollectionABCs(ABCTestCase):
                 return result
             def __repr__(self):
                 return "MySet(%s)" % repr(list(self))
-        s = MySet([5,43,2,1])
-        self.assertEqual(s.pop(), 1)
+        items = [5,43,2,1]
+        s = MySet(items)
+        r = s.pop()
+        self.assertEquals(len(s), len(items) - 1)
+        self.assertNotIn(r, s)
+        self.assertIn(r, items)
 
     def test_issue8750(self):
         empty = WithSet()


### PR DESCRIPTION
Changes the test to not assert concrete result of `pop`, but just that it was an item from the set, and that the set shrunk by one.

The `pop` method of `MutableSet` iterates the underlying set object to choose the item to remove. According the the Python language reference "sets do not record element position or order of insertion".

Note: changing the values in the original test to, for example:

```
        s = MySet([42,43,2,1])
        self.assertEqual(s.pop(), 42)
```

gives

```
FAIL: test_issue_4920 (test.test_collections.TestCollectionABCs)
----------------------------------------------------------------------
    self.assertEqual(s.pop(), 42)
AssertionError: 2 != 42
```

Background: we discovered this issue while developing [GraalPython](github.com/oracle/graalpython), where a small difference in internal implementation leads to `pop()` giving a different value in this case.